### PR TITLE
Add build deps installation script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,10 @@ before_install:
   - rm rust-toolchain
   - unset RUSTC_WRAPPER
   - rustup component add rustfmt clippy
-  - sudo apt-get update || true
-  - sudo apt-get install -y libpq-dev
+  - bash src/deploy/deps.sh
   - wget -q -O - https://github.com/Kitware/CMake/releases/download/v3.15.2/cmake-3.15.2-Linux-x86_64.sh > /tmp/cmake.sh
   - sudo bash /tmp/cmake.sh --skip-license --prefix=/usr
   - sudo rm -rf /usr/local/cmake-* # this is hack to make script use new cmake version
-  - cargo install cbindgen --version 0.9.1 -Z install-upgrade
-  - cargo install mdbook --version 0.3.1 --no-default-features --features search -Z install-upgrade
   - if [ "$SECRET_ENABLED" = "1" ]; then
         wget -q -O - https://files.viva64.com/etc/pubkey.txt | sudo apt-key add -;
         sudo wget -O /etc/apt/sources.list.d/viva64.list https://files.viva64.com/etc/viva64.list;

--- a/Readme.md
+++ b/Readme.md
@@ -15,9 +15,14 @@ mkdir build && cd build
 # This will automatically include most of JJS features. See ../configure --help for possible options
 ../configure --prefix /opt/jjs
 
-# Install packages
-sudo apt-get install libpq-dev
-sudo apt-get install libssl-dev
+# Install dependencies
+make deps
+
+## Alternatively, you can do it manually:
+# sudo apt-get install libpq-dev
+# sudo apt-get install libssl-dev
+# cargo install cbindgen
+# cargo install mdbook
 
 # Now, start build. This will also install JJS
 # If you don't have make installed, run ./make

--- a/src/deploy/bin/configure.rs
+++ b/src/deploy/bin/configure.rs
@@ -80,8 +80,15 @@ fn generate_make_script(src: &str, build: &str) {
         .to_str()
         .unwrap()
         .to_string();
+    let deps_script_path = format!("{}/src/deploy/deps.sh", &src);
+    let full_deps_script_path = std::fs::canonicalize(&deps_script_path)
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
     let makefile = MAKEFILE_TPL
         .replace("___SCRIPT_PATH___", &full_script_path)
+        .replace("___DEPS_SCRIPT_PATH___", &full_deps_script_path)
         .replace("    ", "\t");
     let makefile_path = format!("{}/Makefile", &build);
     std::fs::write(&makefile_path, makefile).unwrap();

--- a/src/deploy/deps.sh
+++ b/src/deploy/deps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+packages="libpq-dev libssl-dev cmake"
+
+if command -v sudo >/dev/null
+then sudo=sudo
+else sudo=
+fi
+
+if command -v apt >/dev/null
+then apt='apt'
+elif command -v apt-get >/dev/null
+then apt='apt-get'
+else echo "Warning: apt not found!
+You're probably using a non-Debian-based distribution. To build JJS you must install the development packages of libpq and OpenSSL." >&2
+fi
+
+if [ "x$apt" != x ]
+then $sudo $apt update
+# shellcheck disable=SC2086
+$sudo $apt install $packages
+fi
+
+cargo install cbindgen -Z install-upgrade
+cargo install mdbook -Z install-upgrade

--- a/src/deploy/makefile.tpl
+++ b/src/deploy/makefile.tpl
@@ -1,3 +1,5 @@
 PHONY: all
 all:
     +bash ___SCRIPT_PATH___
+deps:
+    +bash ___DEPS_SCRIPT_PATH___


### PR DESCRIPTION
`src/deploy/deps.sh` will automatically install non-trivial JJS build dependencies.