### PR TITLE
Run CI on master

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - staging
       - trying
+      - master
 env:
   CI: 1
   RUST_BACKTRACE: full


### PR DESCRIPTION
# Reason
Since #188, actions/cache is used to speed up `e2e` job.
However, with current setup no caches are created for `master` branch, so at least one commit in each branch would be build with `cache-miss`.
