### PR TITLE
Basic restrictions in urprivileged user creation

### DIFF
--- a/src/frontend-engine/src/api/users.rs
+++ b/src/frontend-engine/src/api/users.rs
@@ -9,6 +9,12 @@ pub(super) fn create(
     groups: Vec<String>,
 ) -> ApiResult<schema::User> {
     // TODO transaction
+    if !groups.is_empty() {
+        let access_checker = ctx.access();
+        if !access_checker.is_sudo().internal(ctx)? {
+            return Err(ApiError::access_denied(ctx));
+        }
+    }
     let cur_user = ctx.db.user_try_load_by_login(&login).internal(ctx)?;
     if let Some(..) = cur_user {
         return Err(ApiError::new(ctx, "UserAlreadyExists"));

--- a/src/frontend-engine/src/test_util.rs
+++ b/src/frontend-engine/src/test_util.rs
@@ -73,7 +73,7 @@ impl std::fmt::Display for ErrorPrettyPrinter<'_> {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct RequestBuilder {
     vars: std::collections::HashMap<String, serde_json::Value>,
     operation: Option<String>,

--- a/src/frontend-engine/tests/authn.rs
+++ b/src/frontend-engine/tests/authn.rs
@@ -1,0 +1,114 @@
+mod common;
+
+use common::{Env, RequestBuilder};
+use serde_json::json;
+
+const EMPTY_GROUPS: &[String; 0] = &[];
+
+impl<'a> RequestBuilder<'a> {
+    fn create_user(
+        &mut self,
+        name: &str,
+        password: &str,
+        groups: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> &mut Self {
+        self.operation(
+            r#"
+mutation CreateUser($login: String!, $password: String!, $groups: [String!]!) {
+    createUser(login: $login, password: $password, groups: $groups) {
+        login
+    }
+}
+"#,
+        )
+        .var("login", name)
+        .var("password", password)
+        .var(
+            "groups",
+            groups
+                .into_iter()
+                .map(|x| serde_json::Value::String(x.as_ref().to_string()))
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+impl Env {
+    fn login(&self, login: &str, password: &str) -> String {
+        let res = self
+            .req()
+            .operation(
+                "
+mutation LogIn($login: String!, $password: String!) {
+    authSimple(login:$login, password: $password) {
+        data
+    }
+}        
+        ",
+            )
+            .var("login", login)
+            .var("password", password)
+            .exec()
+            .unwrap_ok();
+
+        res.pointer("/authSimple/data")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+}
+
+/// tests that multiple users with same login are not allowed
+#[test]
+fn test_user_already_exists() {
+    let env = Env::new("UserOps");
+    let res = env
+        .req()
+        .create_user("JonSnow", "VerySecretPass", EMPTY_GROUPS)
+        .exec()
+        .unwrap_ok();
+    assert_eq!(
+        res,
+        json!({
+            "createUser": {
+                "login": "JonSnow"
+            }
+        })
+    );
+
+    let res = env
+        .req()
+        .create_user("JonSnow", "VerySecretPass", EMPTY_GROUPS)
+        .exec()
+        .unwrap_errs();
+    assert_eq!(res.len(), 1);
+    common::check_error(&res[0], "UserAlreadyExists");
+}
+
+#[test]
+fn test_groups() {
+    let env = Env::new("Groups");
+    let res = env
+        .req()
+        .create_user("Alice", "pswrd", &["bar"])
+        .exec()
+        .unwrap_ok();
+    assert_eq!(
+        res,
+        json!({
+            "createUser": {
+                "login": "Alice"
+            }
+        })
+    );
+    let token = env.login("Alice", "pswrd");
+    let errs = env
+        .req()
+        .auth(token)
+        .create_user("Bob", "pswrd", &["bar"])
+        .exec()
+        .unwrap_errs();
+    assert_eq!(errs.len(), 1);
+    common::check_error(&errs[0], "AccessDenied");
+}

--- a/src/frontend-engine/tests/common/mod.rs
+++ b/src/frontend-engine/tests/common/mod.rs
@@ -1,3 +1,5 @@
+// This file is included in many tests, and some functions are not used in all tests
+#![allow(dead_code)]
 use frontend_engine::{config, test_util, ApiServer};
 pub use test_util::check_error;
 
@@ -102,14 +104,28 @@ pub struct RequestBuilder<'a> {
     client: &'a rocket::local::Client,
 }
 
+impl std::fmt::Debug for RequestBuilder<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("ReguestBuidler")
+            .field("builder", &self.builder)
+            .field("auth_token", &self.auth_token)
+            .finish()
+    }
+}
+
 impl RequestBuilder<'_> {
-    pub fn var(&mut self, name: &str, val: &serde_json::Value) -> &mut Self {
-        self.builder.var(name, val);
+    pub fn var(&mut self, name: &str, val: impl Into<serde_json::Value>) -> &mut Self {
+        self.builder.var(name, &val.into());
         self
     }
 
     pub fn operation(&mut self, op: &str) -> &mut Self {
         self.builder.operation(op);
+        self
+    }
+
+    pub fn auth(&mut self, token: impl ToString) -> &mut Self {
+        self.auth_token = Some(token.to_string());
         self
     }
 

--- a/src/frontend-engine/tests/gql.rs
+++ b/src/frontend-engine/tests/gql.rs
@@ -25,49 +25,6 @@ query GetApiVersion {
     )
 }
 
-/// tests various operations with user
-#[test]
-fn test_user_ops() {
-    let env = common::Env::new("UserOps");
-    let res = env
-        .req()
-        .operation(
-            r#"
-mutation CreateAUser {
-    createUser(login: "JonSnow", password: "VerySecretPass", groups: []) {
-        login
-    }
-}
-    "#,
-        )
-        .exec()
-        .unwrap_ok();
-    assert_eq!(
-        res,
-        json!({
-            "createUser": {
-                "login": "JonSnow"
-            }
-        })
-    );
-
-    let res = env
-        .req()
-        .operation(
-            r#"
-mutation CreateSameUserAgain {
-    createUser(login: "JonSnow", password: "VerySecretPass", groups: []) {
-        login
-    }
-}
-        "#,
-        )
-        .exec()
-        .unwrap_errs();
-    assert_eq!(res.len(), 1);
-    common::check_error(&res[0], "UserAlreadyExists");
-}
-
 ///  tests operations with run
 ///  Since it is not end-to-end test, it doesn't check judging
 #[test]
@@ -124,7 +81,7 @@ mutation CreateRun($runCode: String!) {
 }
     "#,
         )
-        .var("runCode", &json!(run_encoded))
+        .var("runCode", json!(run_encoded))
         .exec()
         .unwrap_ok();
     assert_eq!(


### PR DESCRIPTION
Now unprivileged user can not specify nonempty `groups` when calling `Mutation::createUser`.

bors r+