### PR TITLE
Removed confusing ===

### DIFF
--- a/src/frontend-engine/src/root_auth.rs
+++ b/src/frontend-engine/src/root_auth.rs
@@ -47,7 +47,7 @@ fn handle_conn(fcfg: &FrontendConfig, mut conn: UnixStream) {
             return;
         }
     };
-    let message = format!("==={}===\n", token);
+    let message = format!("{}\n", token);
     conn.write_all(message.as_bytes()).ok();
 }
 


### PR DESCRIPTION
=== confuses admins. They think that this is part of the token.